### PR TITLE
database configuration info link update

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -42,7 +42,7 @@ const options = {
     }),
   ],
   // Database optional. MySQL, Maria DB, Postgres and MongoDB are supported.
-  // https://next-auth.js.org/configuration/database
+  // https://next-auth.js.org/configuration/databases
   //
   // Notes:
   // * You must to install an appropriate node_module for your database


### PR DESCRIPTION
I've noticed the link for the database configurations info wasn't working, just needed 's' to the end.