### PR TITLE
wrong license in package.json (npmjs & co)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start"
   },
   "author": "Iain Collins <me@iaincollins.com>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "next": "^10.0.5",
     "next-auth": "^3.1.0",


### PR DESCRIPTION
The ``package.json`` had the wrong license information, so the ``next-auth-example`` repo is **MIT** on GitHub, but **ISC** on npmjs.com.

![image](https://user-images.githubusercontent.com/987947/104053497-a6a61a00-51eb-11eb-889c-7b778d9b9338.png)

![image](https://user-images.githubusercontent.com/987947/104053501-a86fdd80-51eb-11eb-8331-365e2e8f1115.png)
