### PR TITLE
update to [...nextuath].js pages section

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -84,6 +84,8 @@ export default NextAuth({
   },
 
   // You can define custom pages to override the built-in pages.
+  // For custom pages the ensure that they are placed in path outside of the '/api' folder
+  // e.g. signIn: '/auth/mycustom-signin'
   // The routes shown here are the default URLs that will be used when a custom
   // pages is not specified for that route.
   // https://next-auth.js.org/configuration/pages

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -83,9 +83,8 @@ export default NextAuth({
     // decode: async ({ secret, token, maxAge }) => {},
   },
 
-  // You can define custom pages to override the built-in pages.
-  // For custom pages the ensure that they are placed in path outside of the '/api' folder
-  // e.g. signIn: '/auth/mycustom-signin'
+  // You can define custom pages to override the built-in ones. These will be regular Next.js pages
+  // so ensure that they are placed outside of the '/api' folder, e.g. signIn: '/auth/mycustom-signin'
   // The routes shown here are the default URLs that will be used when a custom
   // pages is not specified for that route.
   // https://next-auth.js.org/configuration/pages


### PR DESCRIPTION
Helper comment to show that custom pages should be placed outside of the /api folder so as not to confuse with the default route URLs in the pages options comment block