### PR TITLE
Image url value must be quoted within a string template

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -41,7 +41,7 @@ export default function Header() {
             <>
               {session.user.image && (
                 <span
-                  style={{ backgroundImage: `url(${session.user.image})` }}
+                  style={{ backgroundImage: `url('${session.user.image}')` }}
                   className={styles.avatar}
                 />
               )}


### PR DESCRIPTION
In the latest Chrome and Edge browsers (I didn't test any others) the profile image was not displaying until the value was quoted. I was also using the Azure Active Directory Provider.
