### PR TITLE
Update access-denied.js

### DIFF
--- a/components/access-denied.js
+++ b/components/access-denied.js
@@ -1,15 +1,20 @@
 import { signIn } from 'next-auth/react'
+import Link from 'next/link'
 
-export default function AccessDenied () {
+export default function AccessDenied() {
   return (
     <>
       <h1>Access Denied</h1>
       <p>
-        <a href="/api/auth/signin"
-           onClick={(e) => {
-           e.preventDefault()
-           signIn()
-        }}>You must be signed in to view this page</a>
+        <Link
+          href="/api/auth/signin"
+          onClick={(e) => {
+            e.preventDefault()
+            signIn()
+          }}
+        >
+          <a>You must be signed in to view this page</a>
+        </Link>
       </p>
     </>
   )


### PR DESCRIPTION
Do not use the HTML <a> tag to navigate to /api/auth/signin/.
Use Link from 'next/link' instead.
See: https://nextjs.org/docs/messages/no-html-link-for-pages. @next/next/no-html-link-for-pages