### PR TITLE
Fix Configuration>Providers documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For more information about setting up a database, please check out the following
 
   e.g. For Google OAuth you would use: `http://localhost:3000/api/auth/callback/google`
 
-  A list of configured providers and their callback URLs is available from the endpoint `/api/auth/providers`. You can find more information at https://next-auth.js.org/configuration/providers
+  A list of configured providers and their callback URLs is available from the endpoint `/api/auth/providers`. You can find more information at https://next-auth.js.org/configuration/providers/oauth
 
 3. You can also choose to specify an SMTP server for passwordless sign in via email.
 


### PR DESCRIPTION
Hey,

I was going through this starter repo to learn Next-Auth and I saw that this link that goes to the providers configuration docs redirects to a 404 page:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/47185402/150229529-2f8fba7c-4211-4646-b205-6ead4c6ff115.png">

I fixed it to redirect to the first page mentioning Providers configuration: https://next-auth.js.org/configuration/providers/oauth