### PR TITLE
remove invisible space char

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,5 @@
 NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET​= # Linux: `openssl rand -hex 32` or go to https://generate-secret.now.sh/32
+NEXTAUTH_SECRET= # Linux: `openssl rand -hex 32` or go to https://generate-secret.now.sh/32
 
 APPLE_ID=
 APPLE_TEAM_ID=

--- a/pages/api/examples/jwt.ts
+++ b/pages/api/examples/jwt.ts
@@ -2,7 +2,7 @@
 import { getToken } from "next-auth/jwt"
 import type { NextApiRequest, NextApiResponse } from "next"
 
-const secret = process.env.NEXTAUTH_SECRET​
+const secret = process.env.NEXTAUTH_SECRET
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const token = await getToken({ req, secret })


### PR DESCRIPTION
https://github.com/nextauthjs/next-auth-example/pull/60 seems to have introduced an invisible space at the end of `NEXTAUTH_SECRET`

this pr removes it again

![image](https://user-images.githubusercontent.com/1765075/152691477-726d331d-7798-4921-8446-d5e60cabfe56.png)


