### PR TITLE
Fix #5014 - Replace null content while loading with actual content for /protected

### DIFF
--- a/pages/protected.tsx
+++ b/pages/protected.tsx
@@ -20,7 +20,7 @@ export default function ProtectedPage() {
     fetchData()
   }, [session])
 
-  // Server renders this contents unless you pass session to
+  // Server renders this content unless you pas thes session to
   // getServerSideProps. See `server.tsx` for the detail.
   if (loading) {
     return <Layout>Loading a session</Layout>

--- a/pages/protected.tsx
+++ b/pages/protected.tsx
@@ -20,8 +20,11 @@ export default function ProtectedPage() {
     fetchData()
   }, [session])
 
-  // When rendering client side don't display anything until loading is complete
-  if (typeof window !== "undefined" && loading) return null
+  // Server renders this contents unless you pass session to
+  // getServerSideProps. See `server.tsx` for the detail.
+  if (loading) {
+    return <Layout>Loading a session</Layout>
+  }
 
   // If no session exists, display access denied message
   if (!session) {


### PR DESCRIPTION
This fixes the behavior discussed in [#5014](https://github.com/nextauthjs/next-auth/issues/5014) where the contents of the protected page are rendered twice due to a mismatch in hydration. 

Simply removing the "return null" line would result in a brief rendering of `Access Denied even if the session exists as the server does not have access to the `session` object unless `unstable_getServerSession` is called in `getServerSideProps`.

This implementation will let the server renders a `loading` state with the layout largely intact. Then renders session information such as "Denied" or "Protected content" on the client side.