### PR TITLE
Remove invalid Link tag with <a> child

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
         </li>
         <li className={styles.navItem}>
           <Link href="/policy">
-            <a>Policy</a>
+            Policy
           </Link>
         </li>
         <li className={styles.navItem}>


### PR DESCRIPTION
Fixes the `<Link>` tag by removing the `<a>` child in favor of enabling `<Link legacyBehavior>`.

More details: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor