### PR TITLE
Fix Server Session

### DIFF
--- a/pages/server.tsx
+++ b/pages/server.tsx
@@ -1,11 +1,13 @@
 import { unstable_getServerSession } from "next-auth/next"
+import { useSession } from "next-auth/react"
 import { authOptions } from "./api/auth/[...nextauth]"
 import Layout from "../components/layout"
 
 import type { GetServerSidePropsContext } from "next"
-import type { Session } from "next-auth"
 
-export default function ServerSidePage({ session }: { session: Session }) {
+
+export default function ServerSidePage() {
+  const { data: session } = useSession()
   // As this page uses Server Side Rendering, the `session` will be already
   // populated on render without needing to go through a loading stage.
   return (
@@ -35,13 +37,14 @@ export default function ServerSidePage({ session }: { session: Session }) {
 
 // Export the `session` prop to use sessions with Server Side Rendering
 export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const session = await unstable_getServerSession(
+    context.req,
+    context.res,
+    authOptions
+  );
   return {
     props: {
-      session: await unstable_getServerSession(
-        context.req,
-        context.res,
-        authOptions
-      ),
+      session: JSON.parse(JSON.stringify(session)),
     },
   }
 }


### PR DESCRIPTION
The server-side auth example never really worked, as the `session` was never passed to the component. You can replicate it by going to https://next-auth-example.vercel.app/server and signing in. It does not display the session data...

Once we use `useSession` the session data is available in the component. 

We then run into another Error:

```
Error serializing `.session.user.email` returned from `getServerSideProps` in "/server".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
```

This can be resolved by using `JSON.parse(JSON.stringify(session))`. Another option would be to use `superjson` but I think that belongs in another PR.
