### PR TITLE
Admin page link was missing, so I fixed the link.

### DIFF
--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -7,7 +7,7 @@ export default function Page() {
       <p>Only admin users can see this page.</p>
       <p>
         To learn more about the NextAuth middleware see&nbsp;
-        <a href="https://docs-git-misc-docs-nextauthjs.vercel.app/configuration/nextjs#middleware">
+        <a href="https://next-auth.js.org/configuration/nextjs#middleware">
           the docs
         </a>
         .


### PR DESCRIPTION
The page linked to the Admin page did not exist as shown in the image, so we have corrected the link to what we believe to be the correct one.


<img width="1094" alt="screenshot 2022-12-21 11 08 58" src="https://user-images.githubusercontent.com/44772513/208803951-78cc38d8-47ea-4f73-b62d-4f2b952618be.png">
