### PR TITLE
fix: Outdated link to `Powered By Vercel` image

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Follow the [Deployment documentation](https://next-auth.js.org/deployment)
 ## Acknowledgements
 
 <a href="https://vercel.com?utm_source=nextauthjs&utm_campaign=oss">
-<img width="170px" src="https://raw.githubusercontent.com/nextauthjs/next-auth/canary/www/static/img/powered-by-vercel.svg" alt="Powered By Vercel" />
+<img width="170px" src="https://raw.githubusercontent.com/nextauthjs/next-auth/main/docs/static/img/powered-by-vercel.svg" alt="Powered By Vercel" />
 </a>
 <p align="left">Thanks to Vercel sponsoring this project by allowing it to be deployed for free for the entire NextAuth.js Team</p>
 


### PR DESCRIPTION
## What was done
Fixed a broken image link in the ReadMe.md file.

## Before
![image](https://user-images.githubusercontent.com/2517870/211052799-8f4d7595-b76c-430d-821d-7753c64997fb.png)

## After
![image](https://user-images.githubusercontent.com/2517870/211053097-4297b579-fab8-4b5b-a602-5a3e7796ffb0.png)
