### PR TITLE
fix : Next Auth middleware docs link redirect to not found page

### DIFF
--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -7,7 +7,7 @@ export default function Page() {
       <p>Only admin users can see this page.</p>
       <p>
         To learn more about the NextAuth middleware see&nbsp;
-        <a href="https://docs-git-misc-docs-nextauthjs.vercel.app/configuration/nextjs#middleware">
+        <a href="https://next-auth.js.org/configuration/nextjs#middleware">
           the docs
         </a>
         .


### PR DESCRIPTION
The current link redirect to Not Found page : 

![image](https://user-images.githubusercontent.com/74446624/216759466-8cb536ac-8d39-435b-b7c2-33e91aff08a0.png)


I changed it to working link in `next-auth.js.org` :

![image](https://user-images.githubusercontent.com/74446624/216759546-61d18aeb-6160-4183-83f8-ed9337d08377.png)


Please review if this link is the correct one. Thanks !