### PR TITLE
Removed conflicting route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,0 @@
-import NextAuth from "next-auth/next"
-import { config } from "auth"
-
-const handler = NextAuth(config)
-export { handler as GET, handler as POST }


### PR DESCRIPTION
a41fd08b13aded08afd10b86de00fd8a4efc0c3d introduced a route conflict between two pages:

```bash
 ⨯ Conflicting app and page file was found, please remove the conflicting files to continue:
 ⨯   "pages/api/auth/[...nextauth].ts" - "app/api/auth/[...nextauth]/route.ts"
```

Removing the conflicting route.