### PR TITLE
change to 14.2.1 with 

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,73 +1,11 @@
 import NextAuth from "next-auth"
-
-import Apple from "next-auth/providers/apple"
-import Auth0 from "next-auth/providers/auth0"
-import AzureB2C from "next-auth/providers/azure-ad-b2c"
-import BoxyHQSAML from "next-auth/providers/boxyhq-saml"
-import Cognito from "next-auth/providers/cognito"
-import Coinbase from "next-auth/providers/coinbase"
-import Discord from "next-auth/providers/discord"
-import Dropbox from "next-auth/providers/dropbox"
-import Facebook from "next-auth/providers/facebook"
 import GitHub from "next-auth/providers/github"
-import Gitlab from "next-auth/providers/gitlab"
-import Google from "next-auth/providers/google"
-import Hubspot from "next-auth/providers/hubspot"
-import Keycloak from "next-auth/providers/keycloak"
-import LinkedIn from "next-auth/providers/linkedin"
-import Netlify from "next-auth/providers/netlify"
-import Okta from "next-auth/providers/okta"
-import Passage from "next-auth/providers/passage"
-import Pinterest from "next-auth/providers/pinterest"
-import Reddit from "next-auth/providers/reddit"
-import Slack from "next-auth/providers/slack"
-import Spotify from "next-auth/providers/spotify"
-import Twitch from "next-auth/providers/twitch"
-import Twitter from "next-auth/providers/twitter"
-import WorkOS from "next-auth/providers/workos"
-import Zoom from "next-auth/providers/zoom"
 
 import type { NextAuthConfig } from "next-auth"
 
 export const config = {
-  theme: { logo: "https://authjs.dev/img/logo-sm.png" },
   providers: [
-    Apple,
-    Auth0,
-    AzureB2C({
-      clientId: process.env.AUTH_AZURE_AD_B2C_ID,
-      clientSecret: process.env.AUTH_AZURE_AD_B2C_SECRET,
-      issuer: process.env.AUTH_AZURE_AD_B2C_ISSUER,
-    }),
-    BoxyHQSAML({
-      clientId: "dummy",
-      clientSecret: "dummy",
-      issuer: process.env.AUTH_BOXYHQ_SAML_ISSUER,
-    }),
-    Cognito,
-    Coinbase,
-    Discord,
-    Dropbox,
-    Facebook,
     GitHub,
-    Gitlab,
-    Google,
-    Hubspot,
-    Keycloak,
-    LinkedIn,
-    Netlify,
-    Okta,
-    Passage,
-    Pinterest,
-    Reddit,
-    Slack,
-    Spotify,
-    Twitch,
-    Twitter,
-    WorkOS({
-      connection: process.env.AUTH_WORKOS_CONNECTION,
-    }),
-    Zoom,
   ],
   basePath: "/auth",
   callbacks: {

--- a/auth.ts
+++ b/auth.ts
@@ -7,7 +7,6 @@ export const config = {
   providers: [
     GitHub,
   ],
-  basePath: "/auth",
   callbacks: {
     authorized({ request, auth }) {
       const { pathname } = request.nextUrl

--- a/components/auth-components.tsx
+++ b/components/auth-components.tsx
@@ -1,34 +1,28 @@
-import { signIn, signOut } from "auth"
-import { Button } from "./ui/button"
+"use client";
+
+import { signIn, signOut } from "next-auth/react";
+import { Button } from "./ui/button";
 
 export function SignIn({
   provider,
   ...props
 }: { provider?: string } & React.ComponentPropsWithRef<typeof Button>) {
   return (
-    <form
-      action={async () => {
-        "use server"
-        await signIn(provider)
-      }}
-    >
-      <Button {...props}>Sign In</Button>
-    </form>
-  )
+    <Button {...props} onClick={() => signIn(provider)}>
+      Sign In
+    </Button>
+  );
 }
 
 export function SignOut(props: React.ComponentPropsWithRef<typeof Button>) {
   return (
-    <form
-      action={async () => {
-        "use server"
-        await signOut()
-      }}
-      className="w-full"
+    <Button
+      variant="ghost"
+      className="w-full p-0"
+      onClick={() => signOut()}
+      {...props}
     >
-      <Button variant="ghost" className="w-full p-0" {...props}>
-        Sign Out
-      </Button>
-    </form>
-  )
+      Sign Out
+    </Button>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.274.0",
-    "next": "14.1.4",
+    "next": "14.2.1",
     "next-auth": "beta",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.274.0",
-    "next": "latest",
+    "next": "14.1.4",
     "next-auth": "beta",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Instead of using signIn from auth.ts
```
import { signIn } from '@/app/auth';


export function SignIn({ provider, ...props }: { provider?: string } & React.ComponentPropsWithRef<typeof Button>) {
  return (
    <form
      action={async () => {
        'use server';
        await signIn(provider);
      }}
    >
      <Button {...props}>Sign In</Button>
    </form>
  );
}

```


use signin from next-auth/react

```
"use client";
import { signIn } from "next-auth/react";

export function SignIn({
  provider,
  ...props
}: { provider?: string } & React.ComponentPropsWithRef<typeof Button>) {
  return (
    <Button {...props} onClick={() => signIn(provider)}>
      Sign In
    </Button>
  );
}
```


